### PR TITLE
Update props.conf

### DIFF
--- a/package/default/props.conf
+++ b/package/default/props.conf
@@ -13,7 +13,7 @@
 #
 [aruba:syslog]
 TIME_PREFIX = ^
-TIME_FORMAT = %b %-d %H:%M:%S %Y
+TIME_FORMAT = %b %d %H:%M:%S %Y
 MAX_TIMESTAMP_LOOKAHEAD = 20
 SHOULD_LINEMERGE = true
 LINE_BREAKER = ([\n\r]+)


### PR DESCRIPTION
This hyphen doesn't seem to be valid for Splunk timestamp variables. Lines were merging with it there.